### PR TITLE
Fix inverted anomaly score calculation in HSTrees classifier

### DIFF
--- a/moa/src/main/java/moa/classifiers/oneclass/HSTrees.java
+++ b/moa/src/main/java/moa/classifiers/oneclass/HSTrees.java
@@ -228,7 +228,7 @@ public class HSTrees extends AbstractClassifier implements Classifier, OneClassC
 
 			accumulatedScore = accumulatedScore / (((double) this.numTrees));
 
-			return 0.5 - accumulatedScore + this.anomalyThreshold;
+			return accumulatedScore;
 		}
 	}
 


### PR DESCRIPTION
An [issue](https://github.com/adaptive-machine-learning/CapyMOA/issues/311) has been reported in CapyMOA regarding the inverted anomaly score for HSTree.

The problem is that in the getAnomalyScore function, HSTree incorrectly adjusts the anomaly score based on the threshold. I believe this is unnecessary. Instead, the adjustment should be performed in getVotesForInstance. **However, I think the adjustment may need to ensure that the score is within [0, 1].**

With this PR, the results seem to be good compared to the results in the issue for CapyMOA.

<img width="547" height="413" alt="image" src="https://github.com/user-attachments/assets/a463111b-59c5-4e67-8d30-6e03e22ed1b1" />
